### PR TITLE
Добавил лицензию MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+=====================
+
+Copyright (C) 2017 by fsharplang.ru contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,4 +6,13 @@
 
 [Gitter (чат)](https://gitter.im/fsharplang_ru/Lobby) |
 [Telegram (чат)](https://t.me/Fsharp_chat) |
-[GH pages (testing frontend)](https://fsharplang-ru.github.io) 
+[GH pages (testing frontend)](https://fsharplang-ru.github.io)
+
+-----
+
+Лицензия
+--------
+
+Код сайта распространяется под лицензией [MIT][license].
+
+[license]: LINENSE.md


### PR DESCRIPTION
Все контрибьюторы на данный момент согласились со сменой лицензии на MIT, так что я её добавил.

Fix #6.